### PR TITLE
Add expires header to static content

### DIFF
--- a/django.conf
+++ b/django.conf
@@ -13,6 +13,7 @@ server {
 
 	location /static {
 		alias /opt/django/static; # your Django project's static files - amend as required
+        expires 1h;
 	}
 
 	location / {


### PR DESCRIPTION
Set static content to a 1hr expiry, so that the css, js, and images aren't requested for every HTTP request.
