### PR TITLE
Add 'public' to static cache-control

### DIFF
--- a/django.conf
+++ b/django.conf
@@ -13,7 +13,7 @@ server {
 
 	location /static {
 		alias /opt/django/static; # your Django project's static files - amend as required
-        expires 1h;
+        add_header Cache-Control "public, max-age=3600";
 	}
 
 	location / {

--- a/django.conf
+++ b/django.conf
@@ -14,6 +14,8 @@ server {
 	location /static {
 		alias /opt/django/static; # your Django project's static files - amend as required
         add_header Cache-Control "public, max-age=3600";
+        gzip on;
+        gzip_types text/css text/javascript text/html text/plain text/xml application/x-javascript;
 	}
 
 	location / {


### PR DESCRIPTION
Tested and working this time!

I wanted to make the expiry time configurable via ENV variables, but nginx doesn't seem to support this too well.
